### PR TITLE
add Dockerfile to build and run the tool on Linux easily

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM ubuntu:24.04 AS builder
+
+WORKDIR /app
+
+COPY . /app
+
+RUN apt update
+RUN apt install -y \
+    openjdk-21-jdk-headless \
+    g++ \
+    make \
+    zlib1g-dev
+ENV JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64
+ENV CPLUS_INCLUDE_PATH=$JAVA_HOME/include:$JAVA_HOME/include/linux
+
+RUN cd ViroFBX && make
+
+FROM ubuntu:24.04
+WORKDIR /app
+COPY --from=builder /app/ViroFBX/virofbx .
+
+ENTRYPOINT ["./virofbx"]


### PR DESCRIPTION
sample command to convert a file `/x/in.fbx` into `/x/out.vrx`: `docker run -v /x:/app/x virofbx /app/x/in.fbx /app/x/out.vrx`